### PR TITLE
Handle panic from large integers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -951,8 +951,7 @@ impl Parser {
         let m = res.month.unwrap_or_else(|| default.month() as i32) as u32;
 
         let d_offset = if res.weekday.is_some() && res.day.is_none() {
-            // TODO: Unwrap not justified
-            let dow = day_of_week(y as u32, m, default.day()).unwrap();
+            let dow = day_of_week(y as u32, m, default.day())?;
 
             // UNWRAP: We've already check res.weekday() is some
             let actual_weekday = (res.weekday.unwrap() + 1) % 7;
@@ -963,14 +962,15 @@ impl Parser {
         };
 
         // TODO: Change month/day to u32
-        let d = NaiveDate::from_ymd(
+        let d = NaiveDate::from_ymd_opt(
             y,
             m,
             min(
                 res.day.unwrap_or(default.day() as i32) as u32,
                 days_in_month(y, m as i32)?,
             ),
-        );
+        )
+        .ok_or_else(|| ParseError::ImpossibleTimestamp("Invalid date range given"))?;
 
         let d = d + d_offset;
 

--- a/src/tests/fuzzing.rs
+++ b/src/tests/fuzzing.rs
@@ -45,6 +45,18 @@ fn large_int() {
 }
 
 #[test]
+fn another_large_int() {
+    let parse_result = parse("1412409095009");
+    assert!(parse_result.is_err());
+}
+
+#[test]
+fn an_even_larger_int() {
+    let parse_result = parse("1566997680962280");
+    assert!(parse_result.is_err());
+}
+
+#[test]
 fn empty_string() {
     assert_eq!(parse(""), Err(ParseError::NoDate))
 }


### PR DESCRIPTION
1. Opt to use `NaiveDate::from_ymd_opt` so that a panic can be avoided, this will handle the issue with large integers causing panics.

I added the test case from the issue (and another), which should hopefully fix #26 .