### PR TITLE
Delete unused chrono-tz dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ name = "dtparse"
 
 [dependencies]
 chrono = "0.4"
-chrono-tz = "0.5"
 lazy_static = "1.1"
 num-traits = "0.2"
 rust_decimal = "^0.10.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,6 @@
 extern crate lazy_static;
 
 extern crate chrono;
-extern crate chrono_tz;
 extern crate num_traits;
 extern crate rust_decimal;
 


### PR DESCRIPTION
The chrono-tz dependency has been unused since https://github.com/bspeice/dtparse/pull/20, so removing it.