### PR TITLE
upgrade dependency rust_decimal ^0.10.1 -> 1.17.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,4 @@ name = "dtparse"
 chrono = "0.4"
 lazy_static = "1.1"
 num-traits = "0.2"
-rust_decimal = "^0.10.1"
+rust_decimal = { version = "1.17.0", default-features = false }


### PR DESCRIPTION
Upgrading the dependency will result in projects that depend on this crate no longer pulling in an old or semver-incompatible version of rust_decimal. 
If there are no breaking changes since the last version, is there a patch-release planned in the near future?