### PR TITLE
Don't ship Python scripts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ repository = "https://github.com/bspeice/dtparse.git"
 readme = "README.md"
 categories = ["date-and-time"]
 license = "Apache-2.0"
+exclude = ["/*.py"]
 
 [badges]
 travis-ci = { repository = "bspeice/dtparse" }


### PR DESCRIPTION
This complicates distribution packaging in Fedora as the presence of these files led the dependency generator to assume the crate depends on Python

```
michel in dtparse on  dont-ship-python is 📦 v1.4.0 via 🐍 v3.11.3 via 🦀 v1.69.0 took 6s
⬢ [fedora-toolbox:38] ❯ cargo package --allow-dirty --no-verify
   Packaging dtparse v1.4.0 (/home/michel/src/github/bspeice/dtparse)
    Updating crates.io index
    Packaged 19 files, 175.0KiB (30.7KiB compressed)

michel in dtparse on  dont-ship-python is 📦 v1.4.0 via 🐍 v3.11.3 via 🦀 v1.69.0 took 2s
⬢ [fedora-toolbox:38] ❯ tar tf target/package/dtparse-1.4.0.crate | grep '.py'
dtparse-1.4.0/build_pycompat.py
dtparse-1.4.0/build_pycompat_tokenizer.py
```

```
michel in dtparse on  dont-ship-python [!] is 📦 v1.4.0 via 🐍 v3.11.3 via 🦀 v1.69.0 took 9s
⬢ [fedora-toolbox:38] ❯ cargo package --allow-dirty --no-verify
   Packaging dtparse v1.4.0 (/home/michel/src/github/bspeice/dtparse)
    Updating crates.io index
    Packaged 17 files, 157.4KiB (27.4KiB compressed)

michel in dtparse on  dont-ship-python [!] is 📦 v1.4.0 via 🐍 v3.11.3 via 🦀 v1.69.0
⬢ [fedora-toolbox:38] ❯ tar tf target/package/dtparse-1.4.0.crate | grep '\.py'

michel in dtparse on  dont-ship-python [!] is 📦 v1.4.0 via 🐍 v3.11.3 via 🦀 v1.69.0
⬢ [fedora-toolbox:38] ❯
```